### PR TITLE
Add describe_task_definition API

### DIFF
--- a/server.py
+++ b/server.py
@@ -450,6 +450,31 @@ def discover_poll_endpoint(cluster_arn: Optional[str] = None,
         'serviceConnectEndpoint': response.get('serviceConnectEndpoint', '')
     }
 
+@mcp.tool()
+def describe_task_definition(task_definition: str, include: Optional[List[str]] = None) -> Dict[str, Any]:
+    """
+    Get detailed information about a task definition
+
+    Args:
+        task_definition: The family and revision (family:revision) or full ARN of the task definition
+        include: Specifies whether to see the resource tags for the task definition (optional)
+    """
+    client = get_ecs_client()
+    params = {'taskDefinition': task_definition}
+    
+    if include:
+        params['include'] = include
+    
+    response = client.describe_task_definition(**params)
+    result = {}
+    
+    # Extract relevant fields from the response
+    for key in ['taskDefinition', 'tags', 'compatibilities', 'registeredAt', 'registeredBy', 'deregisteredAt']:
+        if key in response:
+            result[key] = response[key]
+    
+    return result
+
 # Launch server
 if __name__ == "__main__":
     mcp.run()


### PR DESCRIPTION
# What's Changed

- Added implementation of describe_task_definition API
- This API allows users to retrieve detailed information about ECS task definitions
- Parameters:
  - task_definition: Accepts task definition ARN or family:revision format
  - include: Optional parameter to control what information is included in the response

# Testing

- Launch the MCP Server in Claude Desktop
- Test the API to verify it returns the expected task definition details
- Confirm both ARN and family:revision formats work correctly